### PR TITLE
Check for null Pointer in _cogl_gl_util_parse_gl_version

### DIFF
--- a/cogl/driver/gl/cogl-util-gl.c
+++ b/cogl/driver/gl/cogl-util-gl.c
@@ -155,6 +155,9 @@ _cogl_gl_util_parse_gl_version (const char *version_string,
   const char *major_end, *minor_end;
   int major = 0, minor = 0;
 
+  if (version_string == NULL)
+    return FALSE;
+
   /* Extract the major number */
   for (major_end = version_string; *major_end >= '0'
          && *major_end <= '9'; major_end++)


### PR DESCRIPTION
This part of the code crashed gnome-session on some systems when running it with libcogl.so.12.1.1 on Fedora 19.
Those systems have a "NVIDIA Corporation GF106 [GeForce GTS 450] (rev a1)" graphics card with the proprietary driver.
Somehow the version string is a null pointer with those..
