### PR TITLE
cogl: fix compile error with -Werror=maybe-uninitialized

### DIFF
--- a/cogl/driver/gl/gles/cogl-driver-gles.c
+++ b/cogl/driver/gl/gles/cogl-driver-gles.c
@@ -74,9 +74,9 @@ _cogl_driver_pixel_format_to_gl (CoglContext *context,
                                  GLenum *out_gltype)
 {
   CoglPixelFormat required_format;
-  GLenum glintformat;
+  GLenum glintformat = 0;
   GLenum glformat = 0;
-  GLenum gltype;
+  GLenum gltype = 0;
 
   required_format = format;
 


### PR DESCRIPTION
fix below compile error with -Werror=maybe-uninitialized

| ../../cogl-1.22.2/cogl/driver/gl/gles/cogl-driver-gles.c:217:17: error: 'gltype' may be used uninitialized in this function [-Werror=maybe-uninitialized]
|      *out_gltype = gltype;
|      ~~~~~~~~~~~~^~~~~~~~
| ../../cogl-1.22.2/cogl/driver/gl/gles/cogl-driver-gles.c:213:22: error: 'glintformat' may be used uninitialized in this function [-Werror=maybe-uninitialized]
|      *out_glintformat = glintformat;
|      ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~

Signed-off-by: Changqing Li <changqing.li@windriver.com>