### PR TITLE
configure.ac: don't require eglmesaext.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1212,22 +1212,6 @@ AS_IF([test "x$NEED_EGL" = "xyes" && test "x$EGL_CHECKED" != "xyes"],
         PKG_CHECK_EXISTS([egl],
           [COGL_PKG_REQUIRES="$COGL_PKG_REQUIRES egl"],
           [
-            AC_CHECK_HEADERS(
-              [EGL/egl.h],
-              [],
-              [AC_MSG_ERROR([Unable to locate required EGL headers])])
-            AC_CHECK_HEADERS(
-              [EGL/eglext.h],
-              [],
-              [AC_MSG_ERROR([Unable to locate required EGL headers])],
-              [#include <EGL/egl.h>])
-            AC_CHECK_HEADERS(
-              [EGL/eglmesaext.h],
-              [],
-              [AC_MSG_ERROR([Unable to locate required EGL headers])],
-              [#include <EGL/egl.h>
-#include <EGL/eglext.h>])
-
             AC_CHECK_LIB(EGL, [eglInitialize],
               [COGL_EXTRA_LDFLAGS="$COGL_EXTRA_LDFLAGS -lEGL"],
               [AC_MSG_ERROR([Unable to locate required EGL library])])
@@ -1236,9 +1220,23 @@ AS_IF([test "x$NEED_EGL" = "xyes" && test "x$EGL_CHECKED" != "xyes"],
           ]
           )
 
-        COGL_EGL_INCLUDES="#include <EGL/egl.h>
-#include <EGL/eglext.h>
-#include <EGL/eglmesaext.h>"
+        AC_CHECK_HEADERS(
+          [EGL/egl.h],
+          [COGL_EGL_INCLUDES="#include <EGL/egl.h>"],
+          [AC_MSG_ERROR([Unable to locate required EGL headers])])
+        AC_CHECK_HEADERS(
+          [EGL/eglext.h],
+          [COGL_EGL_INCLUDES="$COGL_EGL_INCLUDES
+#include <EGL/eglext.h>"],
+          [AC_MSG_ERROR([Unable to locate required EGL headers])],
+          [$COGL_EGL_INCLUDES])
+        AC_CHECK_HEADERS(
+          [EGL/eglmesaext.h],
+          [COGL_EGL_INCLUDES="$COGL_EGL_INCLUDES
+#include <EGL/eglmesaext.h>"],
+          [],
+          [$COGL_EGL_INCLUDES])
+
         AC_SUBST([COGL_EGL_INCLUDES])
       ])
 


### PR DESCRIPTION
On a build for a i.MX 6 compile fails with:

| .../cogl-egl-defines.h:38:10: fatal error: EGL/eglmesaext.h: No such file or directory
|    38 | #include <EGL/eglmesaext.h>

A egl.pc is provided, so in configure there is no test for the existence of EGL/eglmesaext.h.

If one does not include EGL/eglmesaext.h in COGL_EGL_INCLUDES then the build succeeds.

Change to include EGL/eglmesaext.h only if it actually does exist.